### PR TITLE
Remove any nil's from clipboard/kill-ring list

### DIFF
--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -485,8 +485,8 @@ tag)."
 
 (defun org-web-tools--get-first-url ()
   "Return URL in clipboard, or first URL in the `kill-ring', or nil if none."
-  (cl-loop for item in (append (list (gui-get-selection 'CLIPBOARD))
-                               kill-ring)
+  (cl-loop for item in (remove nil (append (list (gui-get-selection 'CLIPBOARD))
+                                           kill-ring))
            if (string-match (rx bol "http" (optional "s") "://") item)
            return item))
 


### PR DESCRIPTION
When running as `emacs -nw`, 'gui-get-selection' will return nil, thus blowing
up the subsequent 'string-match'.

Fixes https://github.com/alphapapa/org-web-tools/issues/22