### PR TITLE
Expand relative paths in `href` and `src` attributes via `replace-match` in sanitize-html function.

### DIFF
--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -118,6 +118,11 @@
   :group 'org
   :link '(url-link "http://github.com/alphapapa/org-web-tools"))
 
+(defcustom org-web-tools-expand-relative-path nil
+  "TODO"
+  :group 'org-web-tools
+  :type 'boolean)
+
 ;;;; Pandoc support
 
 (defconst org-web-tools--pandoc-no-wrap-option nil

--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -119,7 +119,7 @@
   :link '(url-link "http://github.com/alphapapa/org-web-tools"))
 
 (defcustom org-web-tools-expand-relative-path t
-  "TODO"
+  "Whether or not to expand the relative path in `org-web-tools--sanitize-html'."
   :group 'org-web-tools
   :type 'boolean)
 

--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -444,7 +444,7 @@ first-level entry for writing comments."
                                  (group (+ (not (or ">" "\"" "'")))))
                                 nil t)
         (replace-match (save-match-data (url-expand-file-name (match-string 1) url))
-                       nil nil nil 1)))
+                       nil t nil 1)))
 
     (buffer-string)))
 ;;;;; Misc

--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -402,7 +402,7 @@ first-level entry for writing comments."
   ;;  "%(org-web-tools--url-as-readable-org)")
   (-let* ((url (or url (org-web-tools--get-first-url)))
           (html (org-web-tools--get-url url))
-          (html (org-web-tools--sanitize-html html))
+          (html (org-web-tools--sanitize-html html url))
           ((title . readable) (org-web-tools--eww-readable html))
           (title (org-web-tools--cleanup-title (or title "")))
           (converted (org-web-tools--html-to-org-with-pandoc readable))
@@ -422,8 +422,9 @@ first-level entry for writing comments."
               "** Article" "\n\n")
       (buffer-string))))
 
-(defun org-web-tools--sanitize-html (html)
+(defun org-web-tools--sanitize-html (html &optional url)
   "Sanitize HTML string."
+  (setq url (or url (org-web-tools--get-first-url) ""))
   (with-temp-buffer
     (insert html)
     ;; `libxml-parse-html-region' converts "&nbsp;" to " ", so we have to
@@ -442,8 +443,7 @@ first-level entry for writing comments."
                                  (?  (or "\"" "'"))
                                  (group (+ (not (or ">" "\"" "'")))))
                                 nil t)
-        (replace-match (save-match-data (url-expand-file-name (match-string 1)
-                                                              (org-web-tools--get-first-url)))
+        (replace-match (save-match-data (url-expand-file-name (match-string 1) url))
                        nil nil nil 1)))
 
     (buffer-string)))


### PR DESCRIPTION
Addressing #41 and maybe #45 too?

All the work is done in `org-web-tools--sanitize-html`.

Added a new variable called `org-web-tools-expand-relative-path`.
If it's nil, relative paths won't be expanded.

This works by searching the temporary html buffer created by `org-web-tools--sanitize-html`
for all `href` and `src` attributes, pass the value of each attribute to `url-expand-file-name`,
with the URL argument or the url in user's kill ring being its base, replace the value of the
attribute with the result.

I tested this on a handful of Wikipedia articles and it works just fine. 