### PR TITLE
--html-to-org-with-pandoc reports error from pandoc instead of "Pandoc failed".

### DIFF
--- a/README.org
+++ b/README.org
@@ -48,6 +48,9 @@ After installing from MELPA, just run one of the [[*Usage][commands]] below.  If
 
 ** 1.3-pre
 
+*Changes*
++ Errors from Pandoc are now displayed.  ([[https://github.com/alphapapa/org-web-tools/pull/47][#47]].  Thanks to [[https://github.com/c1-g][c1-g]].)
+
 *Fixes*
 + Default options to Wget (see [[https://github.com/alphapapa/org-web-tools/issues/35][#35]]).
 + Finding URL in clipboard on MacOS and Windows.  (See [[https://github.com/alphapapa/org-web-tools/pull/66][#66]].  Thanks to [[https://github.com/askdkc][@askdkc]].)

--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -151,22 +151,21 @@ When SELECTOR is non-nil, the HTML is filtered using
                     (org-web-tools--dom-to-html))))
   (with-temp-buffer
     (insert html)
-    (let ((err-file (make-temp-file "org-web-tools-pandoc-err")))
+    (let ((stderr-file (make-temp-file "org-web-tools-pandoc-stderr")))
       (unwind-protect
           (if (not (zerop (call-process-region (point-min) (point-max) "pandoc"
-                                               t (list t err-file) nil
+                                               t (list t stderr-file) nil
                                                "--verbose"
                                                (org-web-tools--pandoc-no-wrap-option)
                                                "-f" "html-raw_html-native_divs" "-t" "org")))
-              ;; TODO: Add error output, see org-protocol-capture-html
-              (progn (delete-region (point-min) (point-max))
-                     (goto-char (point-min))
-                     (insert-file-contents err-file)
-                     (error "Pandoc: %s" (buffer-string)))
+              (progn
+                (delete-region (point-min) (point-max))
+                (insert-file-contents stderr-file)
+                (error "Pandoc failed: %s" (buffer-string)))
             (org-mode)
             (org-web-tools--clean-pandoc-output)
             (buffer-string))
-        (delete-file err-file)))))
+        (delete-file stderr-file)))))
 
 (defun org-web-tools--pandoc-no-wrap-option ()
   "Return option `org-web-tools--pandoc-no-wrap-option', setting if unset."

--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -151,15 +151,22 @@ When SELECTOR is non-nil, the HTML is filtered using
                     (org-web-tools--dom-to-html))))
   (with-temp-buffer
     (insert html)
-    (unless (zerop (call-process-region (point-min) (point-max) "pandoc"
-                                        t t nil
-                                        (org-web-tools--pandoc-no-wrap-option)
-                                        "-f" "html-raw_html-native_divs" "-t" "org"))
-      ;; TODO: Add error output, see org-protocol-capture-html
-      (error "Pandoc failed"))
-    (org-mode)
-    (org-web-tools--clean-pandoc-output)
-    (buffer-string)))
+    (let ((err-file (make-temp-file "org-web-tools-pandoc-err")))
+      (unwind-protect
+          (if (not (zerop (call-process-region (point-min) (point-max) "pandoc"
+                                               t (list t err-file) nil
+                                               "--verbose"
+                                               (org-web-tools--pandoc-no-wrap-option)
+                                               "-f" "html-raw_html-native_divs" "-t" "org")))
+              ;; TODO: Add error output, see org-protocol-capture-html
+              (progn (delete-region (point-min) (point-max))
+                     (goto-char (point-min))
+                     (insert-file-contents err-file)
+                     (error "Pandoc: %s" (buffer-string)))
+            (org-mode)
+            (org-web-tools--clean-pandoc-output)
+            (buffer-string))
+        (delete-file err-file)))))
 
 (defun org-web-tools--pandoc-no-wrap-option ()
   "Return option `org-web-tools--pandoc-no-wrap-option', setting if unset."


### PR DESCRIPTION
Here is the patch that makes the process from pandoc replace the
buffer string with its error message and show it throught the capture
buffer. 

This is intended to be used to debug #42.

