### PR TITLE
Fix: timestamp in org-web-tools-read-url-as-org

### DIFF
--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -402,7 +402,7 @@ first-level entry for writing comments."
           (title (org-web-tools--cleanup-title (or title "")))
           (converted (org-web-tools--html-to-org-with-pandoc readable))
           (link (org-make-link-string url title))
-          (timestamp (format-time-string (concat "[" (substring (cdr org-time-stamp-formats) 1 -1) "]"))))
+          (timestamp (format-time-string (concat "[" (cdr org-time-stamp-formats) "]"))))
     (with-temp-buffer
       (org-mode)
       ;; Insert article text


### PR DESCRIPTION
  - based on the new value of org-time-stamp-formats

The value of `org-time-stamp-formats` is updated on the latest master.
https://git.savannah.gnu.org/cgit/emacs/org-mode.git/tree/lisp/org.el#n474