### PR TITLE
call `org-mode` in temp buffer in `--html-to-org-with-pandoc`. FIX #56.

### DIFF
--- a/README.org
+++ b/README.org
@@ -60,6 +60,7 @@ Install [[https://github.com/magnars/dash.el][dash.el]], [[https://github.com/ta
 
 *Compatibility*
 +  Updated for Org 9.3's changes to ~org-bracket-link-regexp~.  (Thanks to [[https://github.com/bcc32][Aaron Zeng]] and [[https://github.com/akirak][Akira Komamura]].)
++  Activate ~org-mode~ in temporary buffer for ~org-web-tools--html-to-org-with-pandoc~.  ([[https://github.com/alphapapa/org-web-tools/issues/56][#56]].  Thanks to [[https://github.com/mooseyboots][mooseyboots]].)
 
 *Fixed*
 +  =org-web-tools--org-link-for-url= now returns the URL if the HTML page has no title tag.  This avoids an error, e.g. when used in an Org capture template.

--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -159,6 +159,7 @@ When SELECTOR is non-nil, the HTML is filtered using
                                         "-f" "html-raw_html-native_divs" "-t" "org"))
       ;; TODO: Add error output, see org-protocol-capture-html
       (error "Pandoc failed"))
+    (org-mode)
     (org-web-tools--clean-pandoc-output)
     (buffer-string)))
 


### PR DESCRIPTION
this fixes #56 for me.

in `org-web-tools--html-to-org-with-pandoc`, we call `(org-mode)` in the temp buffer before we run `(org-web-tools--clean-pandoc-output)`.