### PR TITLE
Update obsolete utility calls

### DIFF
--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -1,5 +1,7 @@
 ;;; org-web-tools.el --- Display and capture web content with Org-mode  -*- lexical-binding: t -*-
 
+;; TODO: Add copyright line.
+
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; Url: http://github.com/alphapapa/org-web-tools
 ;; Version: 1.2-pre

--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -510,7 +510,7 @@ HTML."
 
 (defconst org-web-tools--link-desc-submatch
   (if (version<= "9.3" org-version) 2 3)
-  "Match group index of link description in `org-bracket-link-regexp'.")
+  "Match group index of link description in `org-link-bracket-re'.")
 
 (defun org-web-tools--read-org-bracket-link (&optional link)
   "Return (TARGET . DESCRIPTION) for Org bracket LINK or next link on current line."


### PR DESCRIPTION
few trivial updates to squash load-time warnings due to obsolete identifiers. I've tested on emacs 29.1 and on a build of emacs HEAD as of Monday September 4, 2023. Org mode version 9.7-pre (release_9.6.8-747-gf6fc38). 

now, I am not well versed in the mechanics of maintaining a package that needs to be backwards compatible to some arbitrary point in the past, so this may not be welcome. If this is the case, I'd appreciate a comment on the procedure for this kind of maintenance. :) 

Best regards