### PR TITLE
Fix clipboard issue for macOS and Windows

### DIFF
--- a/README.org
+++ b/README.org
@@ -58,6 +58,7 @@ Install [[https://github.com/magnars/dash.el][dash.el]], [[https://github.com/ta
 
 *Fixes*
 + Default options to Wget (see [[https://github.com/alphapapa/org-web-tools/issues/35][#35]]).
++ Finding URL in clipboard on MacOS and Windows.  (See [[https://github.com/alphapapa/org-web-tools/pull/66][#66]].  Thanks to [[https://github.com/askdkc][@askdkc]].)
 
 *Internal*
 + Use ~plz~ HTTP library and make various related optimizations.

--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -449,7 +449,7 @@ HTML."
 
 (defun org-web-tools--get-first-url ()
   "Return URL in clipboard, or first URL in the `kill-ring', or nil if none."
-  (cl-loop for item in (append (list (gui-get-selection 'CLIPBOARD))
+  (cl-loop for item in (cons (current-kill 0)
                                kill-ring)
            when (and item (string-match (rx bol "http" (optional "s") "://") item))
            return item))

--- a/org-web-tools.el
+++ b/org-web-tools.el
@@ -449,8 +449,7 @@ HTML."
 
 (defun org-web-tools--get-first-url ()
   "Return URL in clipboard, or first URL in the `kill-ring', or nil if none."
-  (cl-loop for item in (cons (current-kill 0)
-                               kill-ring)
+  (cl-loop for item in (cons (current-kill 0) kill-ring)
            when (and item (string-match (rx bol "http" (optional "s") "://") item))
            return item))
 


### PR DESCRIPTION
This PR provides fix for issue #62 

When using this package on macOS, `org-web-tools--get-first-url` needs to use `pbpaste` instead of `org-web-tools--get-first-url`, otherwise, it cannot get URL from clipboard.

**Update: 2023-12-13**
The Issue at https://github.com/alphapapa/org-web-tools/issues/62 is likely just a DNS glitch.
However, the clipboard bug is causing problems for `org-web-tools` on macOS and Windows.
This pull request addresses and resolves both of these issues on these platforms.